### PR TITLE
feat: support ignoreCode

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = function graceful(options) {
   var killTimeout = ms(options.killTimeout || '30s');
   var onError = options.error || function () {};
   var servers = options.servers || options.server || [];
+  var ignoreCode = options.ignoreCode || [];
   if (!Array.isArray(servers)) {
     servers = [servers];
   }
@@ -35,6 +36,12 @@ module.exports = function graceful(options) {
       Date(), process.pid, throwErrorCount);
     console.error(err);
     console.error(err.stack);
+
+    if(ignoreCode.includes(err.code)) {
+      console.error('Error code: %s matches ignore list: %s, don\'t exit.', err.code, '[ ' + ignoreCode.join(', ') + ' ]');
+      return;
+    }
+
     if (throwErrorCount > 1) {
       return;
     }

--- a/test/fixtures/ignore.js
+++ b/test/fixtures/ignore.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var graceful = require('../../');
+var fork = require('child_process').fork;
+var path = require('path');
+
+fork(path.join(__dirname, 'worker.js'));
+
+
+var server = require('http').createServer();
+server.listen();
+graceful({
+  server: server,
+  killTimeout: 2000,
+  ignoreCode: ['EMOCKERROR']
+});
+
+setTimeout(function () {
+  const error = new Error('mock');
+  error.code = 'EMOCKERROR';
+  throw error;
+}, 1000);

--- a/test/ignore.test.js
+++ b/test/ignore.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+var assert = require('assert');
+var path = require('path');
+var fork = require('child_process').fork;
+
+
+describe('test/worker.test.js', () => {
+  it('should kill all children', function (done) {
+    var app = fork(path.join(__dirname, 'fixtures/ignore.js'));
+    setTimeout(function() {
+      assert(alive(app.pid));
+    }, 1000);
+
+    setTimeout(function () {
+      assert(alive(app.pid));
+      done();
+    }, 4000);
+  });
+});
+
+function alive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}


### PR DESCRIPTION
## 背景

在目前 async/await + promise 的 Node 开发模式下，非 `stream` / `socket` 基本不会出现 `uncaughtException` 的问题，而对于 `stream` / `socket` 涉及到 fd 操作的错误，譬如:

```bash
[Error: EBADF: bad file descriptor, write] {
  errno: -9,
  code: 'EBADF',
  syscall: 'write',
  name: 'EBADFError'
}
Error: EBADF: bad file descriptor, write
```

类似这种没有任何可回溯的有用堆栈信息的 `uncaughtException` 造成 `graceful` 触发进程退出，反而会影响到主业务流程的状态。

故此 PR 旨在支持上层开发者定义可忽略（即进程不退出）的错误码，当匹配到传入的 `ignoreCode` 配置错误码，`graceful` 只会输出原始的错误信息，而不会执行后续的退出逻辑。